### PR TITLE
Delete theme config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-tactile


### PR DESCRIPTION
This was auto added from changing Github theme setting and in the UI there's no way to unchoose so I'm deleting this to see if that will restore like I never chose one