### PR TITLE
favicon and og:image energy

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,17 @@
 <meta name="description" content="Energy is in the feels of the identity. Just an equation away.">
 <meta name="theme-color" content="#eee833">
 
+<!-- https://github.com/s9a/E/issues?q=img -->
+<meta property="og:image" content="https://user-images.githubusercontent.com/949985/49286340-b8366880-f44e-11e8-8d16-5625f5abdb1e.png">
+<meta property="og:image:alt" content="helix">
+<meta property="og:image" content="https://user-images.githubusercontent.com/949985/49285520-760c2780-f44c-11e8-9c42-e77618f14e99.png">
+<meta property="og:image:alt" content="E">
+<meta property="og:image" content="https://user-images.githubusercontent.com/949985/49283650-224b0f80-f447-11e8-8592-96e12c2c2113.JPG">
+<meta property="og:image:alt" content="E=she">
+
+<!-- https://github.com/s9a/E/issues?q=favicon -->
+<link rel="shortcut icon" href="https://user-images.githubusercontent.com/949985/49285520-760c2780-f44c-11e8-9c42-e77618f14e99.png">
+
 <style data-via="https://unpkg.com/@s9a/tape@0.2.0/tape.css">
 :root {
   --tape-white: #f5f5f5;


### PR DESCRIPTION
uses images from #5 #6 #7

```html
<!-- https://github.com/s9a/E/issues?q=img -->
<meta property="og:image" content="https://user-images.githubusercontent.com/949985/49286340-b8366880-f44e-11e8-8d16-5625f5abdb1e.png">
<meta property="og:image:alt" content="helix">
<meta property="og:image" content="https://user-images.githubusercontent.com/949985/49285520-760c2780-f44c-11e8-9c42-e77618f14e99.png">
<meta property="og:image:alt" content="E">
<meta property="og:image" content="https://user-images.githubusercontent.com/949985/49283650-224b0f80-f447-11e8-8592-96e12c2c2113.JPG">
<meta property="og:image:alt" content="E=she">

<!-- https://github.com/s9a/E/issues?q=favicon -->
<link rel="shortcut icon" href="https://user-images.githubusercontent.com/949985/49285520-760c2780-f44c-11e8-9c42-e77618f14e99.png">
```